### PR TITLE
Fix erratic Login with Twitter app callback to app

### DIFF
--- a/TwitterKit/TwitterKit/TWTRTwitter.m
+++ b/TwitterKit/TwitterKit/TWTRTwitter.m
@@ -384,7 +384,7 @@ static TWTRTwitter *sharedTwitter;
     BOOL isWeb = [self.mobileSSO isWebWithSourceApplication:sourceApplication];
 
     if (isSSOBundle) {
-        [self.mobileSSO processRedirectURL:url];
+        return [self.mobileSSO processRedirectURL:url];
     } else if (isWeb) {
         BOOL isTokenValid = [self.mobileSSO verifyOauthTokenResponsefromURL:url];
         if (isTokenValid) {


### PR DESCRIPTION
Problem

When processing a redirectURL of a SSO through the Twitter app would sometimes initiate a WebView-based login after an apparently incorrect redirect coming from the Twitter app.

Solution

A return statement wast added to return the result of precessing a redirect URL when using a SSO through the Twitter app.

Result

No change in the API.